### PR TITLE
Faster type check

### DIFF
--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -158,6 +158,8 @@ impl Drop for Value {
     fn drop(&mut self) {
         if self.is_array() {
             unsafe { Array::from_raw(self.0) };
+        } else if self.is_closure() {
+            unsafe { Closure::from_raw(self.0) };
         }
     }
 }

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -8,6 +8,7 @@ use core::{
 
 pub const NIL: Value = Value(0);
 const EXPONENT_MASK: u64 = 0x7ff0 << 48;
+const TYPE_SUB_MASK: usize = 0b111;
 const INTEGER32_SUB_MASK: usize = 0b001;
 const SYMBOL_SUB_MASK: usize = 0b011;
 const CLOSURE_SUB_MASK: usize = 0b010;
@@ -18,6 +19,7 @@ const fn build_mask(sub_mask: usize) -> u64 {
     ((sub_mask as u64) << TYPE_MASK_OFFSET) | EXPONENT_MASK
 }
 
+pub(crate) const TYPE_MASK: u64 = build_mask(TYPE_SUB_MASK);
 pub(crate) const ARRAY_MASK: u64 = build_mask(ARRAY_SUB_MASK);
 pub(crate) const CLOSURE_MASK: u64 = build_mask(CLOSURE_SUB_MASK);
 pub(crate) const SYMBOL_MASK: u64 = build_mask(SYMBOL_SUB_MASK);
@@ -28,11 +30,11 @@ pub struct Value(u64);
 
 impl Value {
     pub fn r#type(&self) -> Type {
-        if self.0 & EXPONENT_MASK == 0 {
+        if self.0 & EXPONENT_MASK != EXPONENT_MASK {
             return Type::Float64;
         }
 
-        match ((self.0 & !EXPONENT_MASK) >> TYPE_MASK_OFFSET) as usize {
+        match ((self.0 >> TYPE_MASK_OFFSET) as usize) & TYPE_SUB_MASK {
             INTEGER32_SUB_MASK => Type::Integer32,
             SYMBOL_SUB_MASK => Type::Symbol,
             CLOSURE_SUB_MASK => Type::Closure,

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -55,8 +55,7 @@ impl Value {
     }
 
     pub fn is_closure(&self) -> bool {
-        // TODO Should closures be non-nil?
-        self.is_nil() || self.r#type() == Type::Closure
+        self.r#type() == Type::Closure
     }
 
     pub fn is_symbol(&self) -> bool {

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -130,16 +130,12 @@ impl Value {
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        if let (Some(one), Some(other)) = (self.as_array(), other.as_array()) {
-            one == other
-        } else if let (Some(one), Some(other)) = (self.to_float64(), other.to_float64()) {
-            one == other
-        } else if let (Some(one), Some(other)) = (self.to_integer32(), other.to_integer32()) {
-            one == other
-        } else if let (Some(one), Some(other)) = (self.to_symbol(), other.to_symbol()) {
-            one == other
-        } else {
-            false
+        match self.r#type() {
+            Type::Float64 => self.to_float64() == other.to_float64(),
+            Type::Closure => false,
+            Type::Integer32 => self.to_integer32() == other.to_integer32(),
+            Type::Array => self.as_array() == other.as_array(),
+            Type::Symbol => self.to_symbol() == other.to_symbol(),
         }
     }
 }

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -28,9 +28,7 @@ pub struct Value(u64);
 
 impl Value {
     pub fn r#type(&self) -> Type {
-        let bits = self.0 & EXPONENT_MASK;
-
-        if bits == 0 {
+        if self.0 & EXPONENT_MASK == 0 {
             return Type::Float64;
         }
 

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -59,7 +59,7 @@ impl Value {
     }
 
     pub fn is_closure(&self) -> bool {
-        self.r#type() == Type::Closure
+        self.is_nil() || self.r#type() == Type::Closure
     }
 
     pub fn is_symbol(&self) -> bool {
@@ -269,7 +269,7 @@ mod tests {
     fn nil_type_check() {
         assert!(NIL.is_nil());
         assert!(NIL.is_array());
-        assert!(!NIL.is_closure());
+        assert!(NIL.is_closure());
         assert!(NIL.is_float64());
         assert!(!NIL.is_symbol());
     }

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -28,7 +28,7 @@ pub(crate) const INTEGER32_MASK: u64 = build_mask(INTEGER32_SUB_MASK);
 pub struct Value(u64);
 
 impl Value {
-    pub fn r#type(&self) -> Type {
+    pub const fn r#type(&self) -> Type {
         if self.0 & EXPONENT_MASK != EXPONENT_MASK {
             return Type::Float64;
         }
@@ -42,7 +42,7 @@ impl Value {
         }
     }
 
-    pub fn is_nil(&self) -> bool {
+    pub const fn is_nil(&self) -> bool {
         self.0 == 0
     }
 
@@ -156,10 +156,14 @@ impl Clone for Value {
 
 impl Drop for Value {
     fn drop(&mut self) {
-        if self.is_array() {
-            unsafe { Array::from_raw(self.0) };
-        } else if self.is_closure() {
-            unsafe { Closure::from_raw(self.0) };
+        match self.r#type() {
+            Type::Array => unsafe {
+                Array::from_raw(self.0);
+            },
+            Type::Closure => unsafe {
+                Closure::from_raw(self.0);
+            },
+            Type::Float64 | Type::Integer32 | Type::Symbol => {}
         }
     }
 }

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -19,7 +19,6 @@ const fn build_mask(sub_mask: usize) -> u64 {
     ((sub_mask as u64) << TYPE_MASK_OFFSET) | EXPONENT_MASK
 }
 
-pub(crate) const TYPE_MASK: u64 = build_mask(TYPE_SUB_MASK);
 pub(crate) const ARRAY_MASK: u64 = build_mask(ARRAY_SUB_MASK);
 pub(crate) const CLOSURE_MASK: u64 = build_mask(CLOSURE_SUB_MASK);
 pub(crate) const SYMBOL_MASK: u64 = build_mask(SYMBOL_SUB_MASK);


### PR DESCRIPTION
# `r#type` optimization

Before:

```sh
> bench/sum/main.sh
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):      62.2 ms ±   0.6 ms    [User: 53.6 ms, System: 6.8 ms]
  Range (min … max):    60.9 ms …  63.6 ms    46 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):      36.3 ms ±   0.4 ms    [User: 32.4 ms, System: 3.1 ms]
  Range (min … max):    35.3 ms …  37.6 ms    75 runs

Summary
  python3 main.py ran
    1.72 ± 0.03 times faster than ../../target/release/arachne < main.arc
```

After:

```sh
> bench/sum/main.sh
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):      57.2 ms ±   0.7 ms    [User: 48.7 ms, System: 6.6 ms]
  Range (min … max):    55.7 ms …  60.0 ms    50 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):      36.4 ms ±   0.4 ms    [User: 32.4 ms, System: 3.2 ms]
  Range (min … max):    35.4 ms …  37.4 ms    75 runs

Summary
  python3 main.py ran
    1.57 ± 0.03 times faster than ../../target/release/arachne < main.arc
```

# `PartialEq` optimization

```sh
> bench/sum/main.sh
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):      56.2 ms ±   0.4 ms    [User: 49.1 ms, System: 6.8 ms]
  Range (min … max):    55.4 ms …  57.1 ms    51 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):      37.6 ms ±   0.5 ms    [User: 33.4 ms, System: 3.4 ms]
  Range (min … max):    36.9 ms …  39.6 ms    71 runs

Summary
  python3 main.py ran
    1.49 ± 0.02 times faster than ../../target/release/arachne < main.arc
```