### PR TITLE
Inline more functions in `vm` crate

### DIFF
--- a/bench/sum/main.sh
+++ b/bench/sum/main.sh
@@ -4,4 +4,4 @@ set -e
 
 cd $(dirname $0)
 
-hyperfine '../../target/release/arachne < main.arc' 'python3 main.py'
+hyperfine -w 2 '../../target/release/arachne < main.arc' 'python3 main.py'

--- a/runtime/src/array.rs
+++ b/runtime/src/array.rs
@@ -12,6 +12,8 @@ use core::{
     ptr::{drop_in_place, write},
 };
 
+// TODO Inline functions.
+
 const UNIQUE_COUNT: usize = 0;
 static STATIC_NIL: Value = NIL;
 

--- a/runtime/src/array.rs
+++ b/runtime/src/array.rs
@@ -48,11 +48,11 @@ impl Array {
     /// # Safety
     ///
     /// The returned array is not cloned and dropped as usual.
-    pub unsafe fn from_raw(ptr: u64) -> Self {
+    pub(crate) unsafe fn from_raw(ptr: u64) -> Self {
         Self(ptr)
     }
 
-    pub fn into_raw(self) -> u64 {
+    pub(crate) fn into_raw(self) -> u64 {
         let ptr = self.0;
 
         forget(self);
@@ -255,7 +255,7 @@ impl TryFrom<Value> for Array {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         if value.is_array() {
-            Ok(unsafe { Array::from_raw(value.into_raw()) })
+            Ok(unsafe { Self::from_raw(value.into_raw()) })
         } else {
             Err(value)
         }

--- a/runtime/src/array.rs
+++ b/runtime/src/array.rs
@@ -40,7 +40,7 @@ impl Array {
     fn mask_ptr(ptr: *const u8) -> u64 {
         let ptr = ptr as u64;
 
-        assert!(ptr & ARRAY_MASK == 0);
+        debug_assert!(ptr & ARRAY_MASK == 0);
 
         ptr | ARRAY_MASK
     }

--- a/runtime/src/closure.rs
+++ b/runtime/src/closure.rs
@@ -22,7 +22,6 @@ struct Header {
 }
 
 impl Closure {
-    #[inline]
     pub fn new(id: ClosureId, arity: u8, environment_size: u8) -> Self {
         let (layout, _) = Layout::new::<Header>()
             .extend(Layout::array::<Value>(environment_size as usize).unwrap())
@@ -48,14 +47,14 @@ impl Closure {
 
     #[inline]
     pub fn get_environment(&self, index: usize) -> &Value {
-        assert!(index < self.header().environment_size as usize);
+        debug_assert!(index < self.header().environment_size as usize);
 
         unsafe { &*self.environment_mut(index) }
     }
 
     #[inline]
     pub fn write_environment(&mut self, index: usize, value: Value) {
-        assert!(index < self.header().environment_size as usize);
+        debug_assert!(index < self.header().environment_size as usize);
 
         unsafe { write(self.environment_mut(index), value) }
     }
@@ -126,7 +125,6 @@ impl Clone for Closure {
 }
 
 impl Drop for Closure {
-    #[inline]
     fn drop(&mut self) {
         if self.is_nil() {
         } else if self.header().count == 0 {

--- a/runtime/src/float64.rs
+++ b/runtime/src/float64.rs
@@ -7,12 +7,14 @@ use ordered_float::OrderedFloat;
 pub struct Float64(f64);
 
 impl Float64 {
+    #[inline]
     pub fn to_f64(self) -> f64 {
         self.0
     }
 }
 
 impl PartialEq for Float64 {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         OrderedFloat::from(self.0) == OrderedFloat::from(other.0)
     }
@@ -27,6 +29,7 @@ impl Display for Float64 {
 }
 
 impl From<f64> for Float64 {
+    #[inline]
     fn from(number: f64) -> Self {
         Self(number)
     }
@@ -35,6 +38,7 @@ impl From<f64> for Float64 {
 impl TryFrom<&Value> for Float64 {
     type Error = ();
 
+    #[inline]
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         if value.is_float64() {
             Ok(f64::from_bits(value.to_raw()).into())
@@ -47,6 +51,7 @@ impl TryFrom<&Value> for Float64 {
 impl TryFrom<Value> for Float64 {
     type Error = Value;
 
+    #[inline]
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         if value.is_float64() {
             Ok(f64::from_bits(value.into_raw()).into())

--- a/runtime/src/integer32.rs
+++ b/runtime/src/integer32.rs
@@ -5,6 +5,8 @@ use core::{
     mem::size_of,
 };
 
+// TODO Inline functions.
+
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Integer32(u64);
 

--- a/runtime/src/symbol.rs
+++ b/runtime/src/symbol.rs
@@ -9,6 +9,8 @@ use core::{
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 
+// TODO Inline functions.
+
 #[allow(clippy::box_collection)]
 static CACHE: Lazy<DashMap<Pin<Box<String>>, ()>> = Lazy::new(Default::default);
 

--- a/runtime/src/value.rs
+++ b/runtime/src/value.rs
@@ -31,6 +31,7 @@ pub(crate) const INTEGER32_MASK: u64 = build_mask(INTEGER32_SUB_MASK);
 pub struct Value(u64);
 
 impl Value {
+    #[inline]
     pub const fn r#type(&self) -> Type {
         if self.0 & EXPONENT_MASK != EXPONENT_MASK {
             return Type::Float64;
@@ -45,58 +46,72 @@ impl Value {
         }
     }
 
+    #[inline]
     pub const fn is_nil(&self) -> bool {
         self.0 == 0
     }
 
+    #[inline]
     pub fn is_array(&self) -> bool {
         self.is_nil() || self.r#type() == Type::Array
     }
 
+    #[inline]
     pub fn is_float64(&self) -> bool {
         self.is_nil() || self.r#type() == Type::Float64
     }
 
+    #[inline]
     pub fn is_integer32(&self) -> bool {
         self.is_nil() || self.r#type() == Type::Integer32
     }
 
+    #[inline]
     pub fn is_closure(&self) -> bool {
         self.is_nil() || self.r#type() == Type::Closure
     }
 
+    #[inline]
     pub fn is_symbol(&self) -> bool {
         self.r#type() == Type::Symbol
     }
 
+    #[inline]
     pub fn to_float64(&self) -> Option<Float64> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn to_integer32(&self) -> Option<Integer32> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn to_symbol(&self) -> Option<Symbol> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn into_array(self) -> Option<Array> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn as_array(&self) -> Option<&Array> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn into_closure(self) -> Option<Closure> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn as_closure(&self) -> Option<&Closure> {
         self.try_into().ok()
     }
 
+    #[inline]
     pub fn as_typed(&self) -> Option<TypedValueRef> {
         if self.is_nil() {
             None
@@ -113,6 +128,7 @@ impl Value {
         }
     }
 
+    #[inline]
     pub fn into_typed(self) -> Option<TypedValue> {
         if self.is_nil() {
             None
@@ -127,7 +143,8 @@ impl Value {
         }
     }
 
-    pub fn into_raw(self) -> u64 {
+    #[inline]
+    pub(crate) fn into_raw(self) -> u64 {
         let raw = self.0;
 
         forget(self);
@@ -135,19 +152,14 @@ impl Value {
         raw
     }
 
-    pub fn to_raw(&self) -> u64 {
+    #[inline]
+    pub(crate) fn to_raw(&self) -> u64 {
         self.0
-    }
-
-    /// # Safety
-    ///
-    /// The raw content must be valid and moved into the new value.
-    pub unsafe fn from_raw(value: u64) -> Self {
-        Self(value)
     }
 }
 
 impl PartialEq for Value {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         if let Some(value) = self.as_typed() {
             match value {
@@ -166,6 +178,7 @@ impl PartialEq for Value {
 impl Eq for Value {}
 
 impl Clone for Value {
+    #[inline]
     fn clone(&self) -> Self {
         if let Some(array) = self.as_array() {
             array.clone().into()
@@ -178,6 +191,7 @@ impl Clone for Value {
 }
 
 impl Drop for Value {
+    #[inline]
     fn drop(&mut self) {
         match self.r#type() {
             Type::Array => unsafe {
@@ -210,72 +224,84 @@ impl Display for Value {
 }
 
 impl From<Array> for Value {
+    #[inline]
     fn from(array: Array) -> Self {
         Self(array.into_raw())
     }
 }
 
 impl From<Closure> for Value {
+    #[inline]
     fn from(closure: Closure) -> Self {
         Self(closure.into_raw())
     }
 }
 
 impl From<Float64> for Value {
+    #[inline]
     fn from(number: Float64) -> Self {
         Self(number.to_f64().to_bits())
     }
 }
 
 impl From<Integer32> for Value {
+    #[inline]
     fn from(number: Integer32) -> Self {
         Self(number.to_raw())
     }
 }
 
 impl From<Symbol> for Value {
+    #[inline]
     fn from(symbol: Symbol) -> Self {
         Self(symbol.to_raw())
     }
 }
 
 impl From<f64> for Value {
+    #[inline]
     fn from(number: f64) -> Self {
         Float64::from(number).into()
     }
 }
 
 impl From<i32> for Value {
+    #[inline]
     fn from(number: i32) -> Self {
         Integer32::from(number).into()
     }
 }
 
 impl From<u32> for Value {
+    #[inline]
     fn from(number: u32) -> Self {
         Integer32::from(number).into()
     }
 }
 
 impl From<String> for Value {
+    #[inline]
     fn from(value: String) -> Self {
         Symbol::from(value).into()
     }
 }
 
 impl From<&str> for Value {
+    #[inline]
     fn from(value: &str) -> Self {
         Symbol::from(value).into()
     }
 }
 
 impl<const N: usize> From<[Value; N]> for Value {
+    #[inline]
     fn from(values: [Value; N]) -> Self {
         Array::from(values).into()
     }
 }
 
 impl From<Vec<Value>> for Value {
+    #[inline]
     fn from(values: Vec<Value>) -> Self {
         Array::from(values).into()
     }

--- a/vm/src/decode.rs
+++ b/vm/src/decode.rs
@@ -1,9 +1,11 @@
 use core::mem::size_of;
 
+#[inline(always)]
 pub fn decode_f64(codes: &[u8], index: &mut usize) -> f64 {
     f64::from_bits(decode_u64(codes, index))
 }
 
+#[inline(always)]
 pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     const SIZE: usize = size_of::<u64>();
     let mut bytes = [0u8; SIZE];
@@ -15,6 +17,7 @@ pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     u64::from_le_bytes(bytes)
 }
 
+#[inline(always)]
 pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     const SIZE: usize = size_of::<u32>();
     let mut bytes = [0u8; SIZE];
@@ -26,6 +29,7 @@ pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     u32::from_le_bytes(bytes)
 }
 
+#[inline(always)]
 pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     const SIZE: usize = size_of::<u16>();
     let mut bytes = [0u8; SIZE];
@@ -37,6 +41,7 @@ pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     u16::from_le_bytes(bytes)
 }
 
+#[inline(always)]
 pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     let value = codes[*index];
 
@@ -45,6 +50,7 @@ pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     value
 }
 
+#[inline(always)]
 pub fn decode_bytes<'a>(codes: &'a [u8], len: usize, index: &mut usize) -> &'a [u8] {
     let value = &codes[*index..*index + len];
 

--- a/vm/src/decode.rs
+++ b/vm/src/decode.rs
@@ -1,11 +1,11 @@
 use core::mem::size_of;
 
-#[inline]
+#[inline(always)]
 pub fn decode_f64(codes: &[u8], index: &mut usize) -> f64 {
     f64::from_bits(decode_u64(codes, index))
 }
 
-#[inline]
+#[inline(always)]
 pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     const SIZE: usize = size_of::<u64>();
     let mut bytes = [0u8; SIZE];
@@ -17,7 +17,7 @@ pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     u64::from_le_bytes(bytes)
 }
 
-#[inline]
+#[inline(always)]
 pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     const SIZE: usize = size_of::<u32>();
     let mut bytes = [0u8; SIZE];
@@ -29,7 +29,7 @@ pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     u32::from_le_bytes(bytes)
 }
 
-#[inline]
+#[inline(always)]
 pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     const SIZE: usize = size_of::<u16>();
     let mut bytes = [0u8; SIZE];
@@ -41,7 +41,7 @@ pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     u16::from_le_bytes(bytes)
 }
 
-#[inline]
+#[inline(always)]
 pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     let value = codes[*index];
 
@@ -50,7 +50,7 @@ pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     value
 }
 
-#[inline]
+#[inline(always)]
 pub fn decode_bytes<'a>(codes: &'a [u8], len: usize, index: &mut usize) -> &'a [u8] {
     let value = &codes[*index..*index + len];
 

--- a/vm/src/decode.rs
+++ b/vm/src/decode.rs
@@ -1,11 +1,11 @@
 use core::mem::size_of;
 
-#[inline(always)]
+#[inline]
 pub fn decode_f64(codes: &[u8], index: &mut usize) -> f64 {
     f64::from_bits(decode_u64(codes, index))
 }
 
-#[inline(always)]
+#[inline]
 pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     const SIZE: usize = size_of::<u64>();
     let mut bytes = [0u8; SIZE];
@@ -17,7 +17,7 @@ pub fn decode_u64(codes: &[u8], index: &mut usize) -> u64 {
     u64::from_le_bytes(bytes)
 }
 
-#[inline(always)]
+#[inline]
 pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     const SIZE: usize = size_of::<u32>();
     let mut bytes = [0u8; SIZE];
@@ -29,7 +29,7 @@ pub fn decode_u32(codes: &[u8], index: &mut usize) -> u32 {
     u32::from_le_bytes(bytes)
 }
 
-#[inline(always)]
+#[inline]
 pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     const SIZE: usize = size_of::<u16>();
     let mut bytes = [0u8; SIZE];
@@ -41,7 +41,7 @@ pub fn decode_u16(codes: &[u8], index: &mut usize) -> u16 {
     u16::from_le_bytes(bytes)
 }
 
-#[inline(always)]
+#[inline]
 pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     let value = codes[*index];
 
@@ -50,7 +50,7 @@ pub fn decode_u8(codes: &[u8], index: &mut usize) -> u8 {
     value
 }
 
-#[inline(always)]
+#[inline]
 pub fn decode_bytes<'a>(codes: &'a [u8], len: usize, index: &mut usize) -> &'a [u8] {
     let value = &codes[*index..*index + len];
 

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -6,32 +6,39 @@ pub struct Stack {
 }
 
 impl Stack {
+    #[inline]
     pub fn new(size: usize) -> Self {
         Self {
             values: Vec::with_capacity(size),
         }
     }
 
+    #[inline]
     pub fn push(&mut self, value: Value) {
         self.values.push(value);
     }
 
+    #[inline]
     pub fn pop(&mut self) -> Value {
         self.values.pop().expect("stack value")
     }
 
+    #[inline]
     pub fn peek(&self, index: usize) -> &Value {
         self.values.get(self.get_index(index)).unwrap()
     }
 
+    #[inline]
     pub fn truncate(&mut self, start: usize, end: usize) {
         self.values.splice(start..end, []);
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
+    #[inline]
     fn get_index(&self, index: usize) -> usize {
         self.values.len() - 1 - index
     }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -6,39 +6,39 @@ pub struct Stack {
 }
 
 impl Stack {
-    #[inline]
+    #[inline(always)]
     pub fn new(size: usize) -> Self {
         Self {
             values: Vec::with_capacity(size),
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn push(&mut self, value: Value) {
         self.values.push(value);
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn pop(&mut self) -> Value {
         self.values.pop().expect("stack value")
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn peek(&self, index: usize) -> &Value {
         self.values.get(self.get_index(index)).unwrap()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn truncate(&mut self, start: usize, end: usize) {
         self.values.splice(start..end, []);
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
-    #[inline]
+    #[inline(always)]
     fn get_index(&self, index: usize) -> usize {
         self.values.len() - 1 - index
     }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -6,39 +6,32 @@ pub struct Stack {
 }
 
 impl Stack {
-    #[inline(always)]
     pub fn new(size: usize) -> Self {
         Self {
             values: Vec::with_capacity(size),
         }
     }
 
-    #[inline(always)]
     pub fn push(&mut self, value: Value) {
         self.values.push(value);
     }
 
-    #[inline(always)]
     pub fn pop(&mut self) -> Value {
         self.values.pop().expect("stack value")
     }
 
-    #[inline(always)]
     pub fn peek(&self, index: usize) -> &Value {
         self.values.get(self.get_index(index)).unwrap()
     }
 
-    #[inline(always)]
     pub fn truncate(&mut self, start: usize, end: usize) {
         self.values.splice(start..end, []);
     }
 
-    #[inline(always)]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
-    #[inline(always)]
     fn get_index(&self, index: usize) -> usize {
         self.values.len() - 1 - index
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -199,7 +199,7 @@ impl Vm {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn call(&mut self, arity: usize) {
         if let Some(closure) = self.stack.peek(arity).as_closure() {
             let id = closure.id();
@@ -223,27 +223,27 @@ impl Vm {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn read_f64(&mut self, codes: &[u8]) -> f64 {
         decode_f64(codes, &mut self.program_counter)
     }
 
-    #[inline(always)]
+    #[inline]
     fn read_u32(&mut self, codes: &[u8]) -> u32 {
         decode_u32(codes, &mut self.program_counter)
     }
 
-    #[inline(always)]
+    #[inline]
     fn read_u16(&mut self, codes: &[u8]) -> u16 {
         decode_u16(codes, &mut self.program_counter)
     }
 
-    #[inline(always)]
+    #[inline]
     fn read_u8(&mut self, codes: &[u8]) -> u8 {
         decode_u8(codes, &mut self.program_counter)
     }
 
-    #[inline(always)]
+    #[inline]
     fn read_bytes<'a>(&mut self, codes: &'a [u8], len: usize) -> &'a [u8] {
         decode_bytes(codes, len, &mut self.program_counter)
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -223,22 +223,27 @@ impl Vm {
         }
     }
 
+    #[inline(always)]
     fn read_f64(&mut self, codes: &[u8]) -> f64 {
         decode_f64(codes, &mut self.program_counter)
     }
 
+    #[inline(always)]
     fn read_u32(&mut self, codes: &[u8]) -> u32 {
         decode_u32(codes, &mut self.program_counter)
     }
 
+    #[inline(always)]
     fn read_u16(&mut self, codes: &[u8]) -> u16 {
         decode_u16(codes, &mut self.program_counter)
     }
 
+    #[inline(always)]
     fn read_u8(&mut self, codes: &[u8]) -> u8 {
         decode_u8(codes, &mut self.program_counter)
     }
 
+    #[inline(always)]
     fn read_bytes<'a>(&mut self, codes: &'a [u8], len: usize) -> &'a [u8] {
         decode_bytes(codes, len, &mut self.program_counter)
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -199,7 +199,7 @@ impl Vm {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn call(&mut self, arity: usize) {
         if let Some(closure) = self.stack.peek(arity).as_closure() {
             let id = closure.id();
@@ -223,27 +223,27 @@ impl Vm {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_f64(&mut self, codes: &[u8]) -> f64 {
         decode_f64(codes, &mut self.program_counter)
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_u32(&mut self, codes: &[u8]) -> u32 {
         decode_u32(codes, &mut self.program_counter)
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_u16(&mut self, codes: &[u8]) -> u16 {
         decode_u16(codes, &mut self.program_counter)
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_u8(&mut self, codes: &[u8]) -> u8 {
         decode_u8(codes, &mut self.program_counter)
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_bytes<'a>(&mut self, codes: &'a [u8], len: usize) -> &'a [u8] {
         decode_bytes(codes, len, &mut self.program_counter)
     }


### PR DESCRIPTION
# Benchmarks

Before:

```sh
> tools/bench.sh
    Finished release [optimized] target(s) in 0.06s
    Updating crates.io index
     Ignored package `hyperfine v1.17.0` is already installed, use --force to override
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):     18.394 s ±  0.210 s    [User: 18.261 s, System: 0.059 s]
  Range (min … max):   18.139 s … 18.750 s    10 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):     12.092 s ±  0.114 s    [User: 12.034 s, System: 0.045 s]
  Range (min … max):   11.953 s … 12.282 s    10 runs

Summary
  python3 main.py ran
    1.52 ± 0.02 times faster than ../../target/release/arachne < main.arc
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):      4.438 s ±  0.063 s    [User: 4.402 s, System: 0.015 s]
  Range (min … max):    4.347 s …  4.548 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: python3 main.py
  Time (mean ± σ):      2.347 s ±  0.049 s    [User: 2.325 s, System: 0.013 s]
  Range (min … max):    2.278 s …  2.451 s    10 runs

Summary
  python3 main.py ran
    1.89 ± 0.05 times faster than ../../target/release/arachne < main.arc
```

After:

```sh
> tools/bench.sh
    Finished release [optimized] target(s) in 0.04s
    Updating crates.io index
     Ignored package `hyperfine v1.17.0` is already installed, use --force to override
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):     12.134 s ±  0.122 s    [User: 12.045 s, System: 0.052 s]
  Range (min … max):   12.029 s … 12.417 s    10 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):     11.780 s ±  0.080 s    [User: 11.711 s, System: 0.056 s]
  Range (min … max):   11.647 s … 11.881 s    10 runs

Summary
  python3 main.py ran
    1.03 ± 0.01 times faster than ../../target/release/arachne < main.arc
Benchmark 1: ../../target/release/arachne < main.arc
  Time (mean ± σ):      3.260 s ±  0.030 s    [User: 3.244 s, System: 0.015 s]
  Range (min … max):    3.220 s …  3.302 s    10 runs

Benchmark 2: python3 main.py
  Time (mean ± σ):      2.296 s ±  0.020 s    [User: 2.278 s, System: 0.016 s]
  Range (min … max):    2.274 s …  2.337 s    10 runs

Summary
  python3 main.py ran
    1.42 ± 0.02 times faster than ../../target/release/arachne < main.arc
```